### PR TITLE
add hitpoint calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # ddb-to-tableplop-character
+
+This script requires the Requests library to be installed.


### PR DESCRIPTION
Add hitpoint calculation.  Currently handles base hitpoints and constitution adjustment, and also hitpoints from Draconic Resilience class feature for draconic origin sorcerers.